### PR TITLE
Fix installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 # Most user installed commands seems to be placed under /usr/local/bin,
 DEFAULT_PREFIX := /usr/local
 prefix ?= ${DEFAULT_PREFIX}
-compdir := /etc/bash_completion.d
-builddir := .build
+override prefix := $(patsubst %/,%,$(prefix))
+DEFAULT_COMPDIR := /etc/bash_completion.d
+compdir := ${DEFAULT_COMPDIR}
+builddir ?= .build
+override builddir := $(patsubst %/,%,$(builddir))
 ifneq (${prefix},${DEFAULT_PREFIX})
 	# Unfortunately bash_completion does not consider /usr/local/etc
-	compdir := ${prefix}${compdir}
+	compdir := ${prefix}${DEFAULT_COMPDIR}
 endif
 
 # Let's color warnings in yellow ...
@@ -36,11 +39,11 @@ install: build
 # (using a conditional statement before mkdir -p avoids trying to
 # recreate /bin and /etc if $prefix is not specified.
 # It not necessary, but maybe it is more polite ...)
-	@[ ! -d "${prefix}/bin" ] && mkdir -p ${prefix}/bin
+	@if [ ! -d "${prefix}/bin" ]; then mkdir -p ${prefix}/bin; fi
 	install -D -t ${prefix}/bin $(builddir)/git-*
-	@[ ! -d "${compdir}" ] && mkdir -p ${compdir}
+	@if [ ! -d "${compdir}" ]; then mkdir -p ${compdir}; fi
 	install -m 664 -D -t ${compdir} etc/bash_completion.d/*
-ifneq (${prefix},${DEFAULT_PREFIX})
+ifneq (${compdir},${DEFAULT_COMPDIR})
 	@${TPUT} bold
 	@${TPUT} setaf 0
 	@${TPUT} setab 3

--- a/README.md
+++ b/README.md
@@ -23,14 +23,21 @@ commits.
 
 ## Installation
 
-To install for all users, download the repository and run `install.sh` with
+To install for all users, download the repository and run `make install` with
 root permissions. This will copy the executables to `/usr/local/bin` and the
 Bash completion script to `/etc/bash_completion.d`.
 
-Otherwise, download the scripts in `bin` directory into a directory in your
-`PATH` environment variable (such as `$HOME/bin`) and, to set up
-auto-completion of arguments in Bash, download the script
-`etc/bash_completion.d/git-to-from-review` and source at Bash startup.
+To install into a specific location, a parameter `prefix` can be passed,
+e.g. `make install prefix=$HOME/.local`. Note that this will not automatically
+set up Bash auto-completion, therefore it will be necessary to source the
+`$prefix/etc/bash_completion.d/git-to-from-review` script at Bash startup.
+
+To uninstall, remove `git-to-review` and `git-from-review` from
+`/usr/local/bin` or `$prefix/bin`, and `git-to-from-review` from
+`/etc/bash_completion.d` if necessary.
+
+Alternatively, for a "more manageable" installation/uninstallation process see
+[GNU Stow](https://www.gnu.org/software/stow/manual/stow.html).
 
 ## Usage
 

--- a/tests/test_make.bats
+++ b/tests/test_make.bats
@@ -29,6 +29,15 @@ teardown() {
   assert_file_exist "$tmpdir/etc/bash_completion.d/git-to-from-review"
 }
 
+@test "accept trailing slash" {
+  # When installing to a different prefix
+  run make install prefix="$tmpdir/"
+  # and the files should be generated under the given prefix
+  assert_file_exist "$tmpdir/bin/git-to-review"
+  assert_file_exist "$tmpdir/bin/git-from-review"
+  assert_file_exist "$tmpdir/etc/bash_completion.d/git-to-from-review"
+}
+
 @test "make do not install by default" {
   # When 'install' is not passed
   make builddir="$tmpdir"


### PR DESCRIPTION
In my last pull-request I forgot to update the installation instructions. A bug when installing to `prefix=/` was also found.

(Do you have any ideia about how to test this specific bug? A direct test is not an option since it changes the developer machine environment and I was not successful experimenting with `chroot`)